### PR TITLE
Update min cmake version

### DIFF
--- a/cmake/ucm.cmake
+++ b/cmake/ucm.cmake
@@ -10,7 +10,7 @@
 # The documentation can be found at the library's page:
 # https://github.com/onqtam/ucm
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 include(CMakeParseArguments)
 


### PR DESCRIPTION
# Summary
Update minimum allowed cmake version.

CMake 4.0 added a hard error when using cmake with allowed version under 3.5:

```
Compatibility with CMake < 3.5 has been removed from CMake.

Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
to tell CMake that the project requires at least <min> but has been updated
to work with policies introduced by <max> or earlier.

Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

This will allow local devs and CI to have cmake 4.0+.